### PR TITLE
NestedTransactions test was included

### DIFF
--- a/src/Castle.Facilities.NHibernate.Tests/Castle.Facilities.NHibernate.Tests.csproj
+++ b/src/Castle.Facilities.NHibernate.Tests/Castle.Facilities.NHibernate.Tests.csproj
@@ -88,10 +88,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="..\CommonAssemblyInfo.cs">
-      <Link>Properties\CommonAssemblyInfo.cs</Link>
-    </Compile>
     <Compile Include="AdvancedUseCase_DependentTransactionsAreNotFlushingToStore.cs" />
+    <Compile Include="NestedTransactions.cs" />
     <Compile Include="InterceptorTests.cs" />
     <Compile Include="LifeStyle\per_web_request_spec.cs" />
     <Compile Include="LifeStyle\transient_resolving_spec.cs" />

--- a/src/Castle.Facilities.NHibernate.Tests/NestedTransactions.cs
+++ b/src/Castle.Facilities.NHibernate.Tests/NestedTransactions.cs
@@ -1,0 +1,97 @@
+﻿// Copyright 2004-2011 Castle Project - http://www.castleproject.org/
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace Castle.Facilities.NHibernate.Tests
+{
+	using System;
+	using System.Collections;
+	using System.Transactions;
+
+	using Castle.Facilities.AutoTx;
+	using Castle.Facilities.AutoTx.Testing;
+	using Castle.Facilities.NHibernate.Tests.Framework;
+	using Castle.Facilities.NHibernate.Tests.TestClasses;
+	using Castle.MicroKernel.Registration;
+	using Castle.Transactions;
+	using Castle.Windsor;
+
+	using NLog;
+
+	using NUnit.Framework;
+
+	using global::NHibernate;
+	using global::NHibernate.SqlCommand;
+	using global::NHibernate.Type;
+
+	using ITransaction = global::NHibernate.ITransaction;
+
+	internal class NestedTransactions : EnsureSchema
+	{
+		private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+		private Container container;
+
+		[SetUp]
+		public void SetUp()
+		{
+			container = new Container();
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			container.Dispose();
+		}
+
+		/// <summary>
+		/// This test shows that several transaction methods can be attached to the same transaction
+		/// </summary>
+		[Test]
+		public void RunTest()
+		{
+			logger.Debug("starting test run");
+
+			using (var x = container.ResolveScope<NestedTransactionService>())
+				x.Service.Run();
+		}
+	}
+
+	public class NestedTransactionService
+	{
+		private static readonly Logger logger = LogManager.GetCurrentClassLogger();
+		private readonly ISessionManager sessionManager;
+		private Guid thingId;
+
+		public NestedTransactionService(ISessionManager sessionManager)
+		{
+			this.sessionManager = sessionManager;
+		}
+
+		[Transaction]
+		public virtual void Run()
+		{
+
+			SaveNewThing();
+			SaveNewThing();
+		}
+
+		[Transaction]
+		protected virtual void SaveNewThing()
+		{
+			var s = sessionManager.OpenSession();
+			var thing = new Thing(18.0);
+			thingId = (Guid)s.Save(thing);
+		}
+
+	}
+}

--- a/src/Castle.Facilities.NHibernate.Tests/ValidationError_OnSave.cs
+++ b/src/Castle.Facilities.NHibernate.Tests/ValidationError_OnSave.cs
@@ -73,6 +73,7 @@ namespace Castle.Facilities.NHibernate.Tests
 			AddFacility<NHibernateFacility>();
 
 			Register(Component.For<Test>().LifeStyle.Transient);
+			Register(Component.For<NestedTransactionService>().LifeStyle.Transient);
 		}
 	}
 
@@ -81,7 +82,7 @@ namespace Castle.Facilities.NHibernate.Tests
 		private static readonly Logger logger = LogManager.GetCurrentClassLogger();
 
 		public bool OnFlushDirty(object entity, object id, object[] currentState, object[] previousState,
-		                         string[] propertyNames, IType[] types)
+														 string[] propertyNames, IType[] types)
 		{
 			logger.Debug("throwing validation exception");
 
@@ -96,7 +97,7 @@ namespace Castle.Facilities.NHibernate.Tests
 		}
 
 		public int[] FindDirty(object entity, object id, object[] currentState, object[] previousState, string[] propertyNames,
-		                       IType[] types)
+													 IType[] types)
 		{
 			return null;
 		}
@@ -178,6 +179,7 @@ namespace Castle.Facilities.NHibernate.Tests
 		}
 	}
 
+
 	public class Test
 	{
 		private static readonly Logger logger = LogManager.GetCurrentClassLogger();
@@ -189,6 +191,7 @@ namespace Castle.Facilities.NHibernate.Tests
 			this.sessionManager = sessionManager;
 		}
 
+		
 		public virtual void Run()
 		{
 			logger.Debug("run invoked");
@@ -232,4 +235,6 @@ namespace Castle.Facilities.NHibernate.Tests
 			return s.Load<Thing>(thingId);
 		}
 	}
+
+	
 }


### PR DESCRIPTION
The NHibernateIntegration Facility has the ability to intercept all the transaction methods in a call stack and combine them into one transaction. 
If you use the Repository Pattern and you want to implement an automatic transaction solution, transaction unawareness is the perfect (desirable) soluction.

This code just shows a desirable behavior. It does not include a possible solution
