### PR TITLE
Note in readme that albacore 2.0 isn't supported

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,8 @@ Currently compiles against NHibernate 3.1 + FluentNHibernate 1.2. Use the wiki f
 # How to build
 
  1. Install Ruby 1.9.2
- 2. `gem install albacore version_bumper`
+ 2. `gem install albacore -v 1` (version 2 has been released but is not supported (yet))
+ 3. `gem install version_bumper`
  3. `git clone https://haf@github.com/haf/Castle.Facilities.NHibernate.git`
  4. `cd "Castle.Facilities.NHibernate"`
  5. `rake`


### PR DESCRIPTION
Since albacore moved to https://github.com/Albacore/albacore, a version 2.0 has been released in which the file structure is a little different. I don't know enough rake/ruby to be able to contribute to updating the build scripts, but I can at least help others figure out how to build the project.

This didn't take me all the way - the rake build still failed - but after installing this version of albacore I could at least get far enough to build in Visual Studio =)
