### PR TITLE
Setting proper GUID for SessionManager

### DIFF
--- a/src/Castle.Facilities.NHibernate/SessionManager.cs
+++ b/src/Castle.Facilities.NHibernate/SessionManager.cs
@@ -31,7 +31,7 @@ namespace Castle.Facilities.NHibernate
 	public class SessionManager : ISessionManager
 	{
 		private readonly Func<ISession> getSession;
-		private Guid privateSessionId = new Guid();
+		private Guid privateSessionId = Guid.NewGuid();
 		private ITransactionManager transactionManager;
 
 		/// <summary>


### PR DESCRIPTION
Using default constructor creates a Guid with value of all zeroes. Using the static method NewGuid() generates a proper Guid.
